### PR TITLE
Replace loading sinatra

### DIFF
--- a/lib/que/web.rb
+++ b/lib/que/web.rb
@@ -1,4 +1,4 @@
-require "sinatra"
+require "sinatra/base"
 require "erubis"
 
 module Que


### PR DESCRIPTION
As `que-web` using `Sinatra::Base` better require only `sinatra/base` instead require `sinatra` which will be extend the main object https://github.com/sinatra/sinatra/blob/master/lib/sinatra/main.rb#L31
For this reason I got a error with my `rake` tasks:
```
$ bundle exec rake -T -t
rake aborted!
NoMethodError: undefined method `task' for Sinatra::Application:Class
/Users/10525/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/sinatra-contrib-1.4.7/lib/sinatra/namespace.rb:272:in `method_missing'
/Users/10525/Projects/test/Rakefile:16:in `block in <top (required)>'
/Users/10525/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/sinatra-contrib-1.4.7/lib/sinatra/namespace.rb:128:in `class_eval'
/Users/10525/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/sinatra-contrib-1.4.7/lib/sinatra/namespace.rb:128:in `block in new'
/Users/10525/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/sinatra-contrib-1.4.7/lib/sinatra/namespace.rb:118:in `initialize'
/Users/10525/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/sinatra-contrib-1.4.7/lib/sinatra/namespace.rb:118:in `new'
/Users/10525/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/sinatra-contrib-1.4.7/lib/sinatra/namespace.rb:118:in `new'
/Users/10525/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/sinatra-contrib-1.4.7/lib/sinatra/namespace.rb:144:in `namespace'
/Users/10525/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/sinatra-1.4.7/lib/sinatra/base.rb:1981:in `block (2 levels) in delegate'
/Users/10525/Projects/test/Rakefile:15:in `<top (required)>'
/Users/10525/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-11.2.2/lib/rake/rake_module.rb:28:in `load'
/Users/10525/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-11.2.2/lib/rake/rake_module.rb:28:in `load_rakefile'
/Users/10525/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-11.2.2/lib/rake/application.rb:686:in `raw_load_rakefile'
/Users/10525/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-11.2.2/lib/rake/application.rb:96:in `block in load_rakefile'
/Users/10525/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-11.2.2/lib/rake/application.rb:178:in `standard_exception_handling'
/Users/10525/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-11.2.2/lib/rake/application.rb:95:in `load_rakefile'
/Users/10525/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-11.2.2/lib/rake/application.rb:79:in `block in run'
/Users/10525/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-11.2.2/lib/rake/application.rb:178:in `standard_exception_handling'
/Users/10525/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-11.2.2/lib/rake/application.rb:77:in `run'
/Users/10525/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-11.2.2/exe/rake:27:in `<top (required)>'
/Users/10525/.rbenv/versions/2.3.3/bin/rake:22:in `load'
/Users/10525/.rbenv/versions/2.3.3/bin/rake:22:in `<top (required)>'
/Users/10525/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.15.0/lib/bundler/cli/exec.rb:74:in `load'
/Users/10525/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.15.0/lib/bundler/cli/exec.rb:74:in `kernel_load'
/Users/10525/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.15.0/lib/bundler/cli/exec.rb:27:in `run'
/Users/10525/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.15.0/lib/bundler/cli.rb:360:in `exec'
/Users/10525/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.15.0/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/Users/10525/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.15.0/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/Users/10525/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.15.0/lib/bundler/vendor/thor/lib/thor.rb:369:in `dispatch'
/Users/10525/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.15.0/lib/bundler/cli.rb:20:in `dispatch'
/Users/10525/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.15.0/lib/bundler/vendor/thor/lib/thor/base.rb:444:in `start'
/Users/10525/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.15.0/lib/bundler/cli.rb:10:in `start'
/Users/10525/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.15.0/exe/bundle:35:in `block in <top (required)>'
/Users/10525/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.15.0/lib/bundler/friendly_errors.rb:121:in `with_friendly_errors'
/Users/10525/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.15.0/exe/bundle:27:in `<top (required)>'
/Users/10525/.rbenv/versions/2.3.3/bin/bundle:22:in `load'
/Users/10525/.rbenv/versions/2.3.3/bin/bundle:22:in `<main>'
```