### PR TITLE
Obtain advisory lock before updating or deleting jobs

### DIFF
--- a/lib/que/web/sql.rb
+++ b/lib/que/web/sql.rb
@@ -43,11 +43,15 @@ Que::Web::SQL = {
     DELETE
     FROM que_jobs
     WHERE job_id = $1::bigint
+    AND pg_try_advisory_lock($1::bigint)
+    RETURNING job_id
   SQL
   reschedule_job: <<-SQL.freeze,
     UPDATE que_jobs
     SET run_at = $2::timestamptz
     WHERE job_id = $1::bigint
+    AND pg_try_advisory_lock($1::bigint)
+    RETURNING job_id
   SQL
   fetch_job: <<-SQL.freeze,
     SELECT *


### PR DESCRIPTION
If we have a failed Que job and press the re-run button when the job is being retried by a worker, we end up scheduling _another_ instance of the job. Similarly, if we try to delete a previously-failed job and it is already being retried, we won't actually delete the job despite the flash telling us that is was deleted.

Both of these scenarios are confusing, and should be avoided (and a warning shown to the user).

The former occurs as when we reschedule a running job, we change the primary key of the job as it is a composite of: `(queue, priority, run_at, job_id)` and by rescheduling we change the `run_at` value. Therefore, when the original (running) job completes and deletes the row(s) matching its primary key, the newly-created row (with the different primary key) won't be deleted.

To fix both scenarios, if we try to take the advisory lock for the job before updating/deleting, we will only reschedule/delete if the job isn't already being worked. This PR adds this attempted locking and shows a flash to accurately describe to the user what has happened.

N.B. to demonstrate the issue a job such as:
```
class SleepJob < Que::Job
  def run
    ActiveRecord::Base.transaction do
      raise 'error first time!' if error_count.zero?

      10.downto(1) do |i|
        print "#{i}..."
        sleep 1
      end

      destroy
    end
  end
end
```
will error first time, if the reschedule button is pressed when it starts running, (i.e. printing `10...9...`)  another job will be enqueued. Similarly if the delete button is pressed when the job runs, it won't actually be deleted and will continue to be run.