### PR TITLE
Fix #34 - ensure job is locked/unlocked exactly once

### DIFF
--- a/lib/que/web/sql.rb
+++ b/lib/que/web/sql.rb
@@ -40,18 +40,21 @@ Que::Web::SQL = {
     OFFSET $2::int
   SQL
   delete_job: <<-SQL.freeze,
-    DELETE
-    FROM que_jobs
+    DELETE FROM que_jobs
     WHERE job_id = $1::bigint
-    AND pg_try_advisory_lock($1::bigint)
-    RETURNING pg_advisory_unlock(job_id)
   SQL
   reschedule_job: <<-SQL.freeze,
     UPDATE que_jobs
     SET run_at = $2::timestamptz
     WHERE job_id = $1::bigint
-    AND pg_try_advisory_lock($1::bigint)
-    RETURNING pg_advisory_unlock(job_id)
+  SQL
+  lock_job: <<-SQL.freeze,
+    SELECT pg_try_advisory_lock(job_id) AS obtained_lock
+    FROM que_jobs
+    WHERE job_id = $1::bigint
+  SQL
+  unlock_job: <<-SQL.freeze,
+    SELECT pg_advisory_unlock($1::bigint)
   SQL
   fetch_job: <<-SQL.freeze,
     SELECT *


### PR DESCRIPTION
We now issue separate queries to lock, modify, and finally unlock a particular job, avoiding the complexity of a single query.

We ensure we only lock a single job once by issuing the lock instruction in the `SELECT` clause, which executes only after identifying the job row by its id (if there are no matching jobs, because the job has already run and been deleted, we do not take any locks)