### PR TITLE
Handle empty last_error strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Unreleased
+- Fix to handle empty last_error strings
+
 ### 0.7.0 - 2018-02-02
 #### Added:
 - Delete All and Reschedule All ([#39](https://github.com/statianzo/que-web/pull/39))

--- a/lib/que/web.rb
+++ b/lib/que/web.rb
@@ -157,7 +157,7 @@ module Que
 
     after { session[FLASH_KEY] = {} if @sweep_flash }
 
-    helpers do
+    module Helpers
       def root_path
         "#{env['SCRIPT_NAME']}/"
       end
@@ -183,7 +183,7 @@ module Que
 
       def format_error(job)
         return unless job.last_error
-        line = job.last_error.lines.first
+        line = job.last_error.lines.first || ''
         truncate line, 30
       end
 
@@ -209,6 +209,7 @@ module Que
         hash[level] = val
       end
     end
+    helpers Helpers
   end
 end
 

--- a/spec/web_spec.rb
+++ b/spec/web_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe Que::Web::Helpers do
+  subject do
+    Class.new { include Que::Web::Helpers }.new
+  end
+
+  def error_job(last_error)
+    Que::Web::Viewmodels::Job.new('last_error' => last_error)
+  end
+
+  describe '#format_error' do
+    it 'returns the truncated first line of the last error' do
+      message = 'This is a really long exception message that should get truncated'
+      last_error = ([message] + caller).join("\n")
+      subject.format_error(
+        error_job(last_error)
+      ).must_equal 'This is a really long exception...'
+    end
+
+    it 'handles empty strings as the last error' do
+      subject.format_error(error_job('')).must_equal ''
+    end
+  end
+end


### PR DESCRIPTION
If the `last_error` of a failed Que job is an empty string (which can
happen on older versions of Que that do not include the stack trace in
the last error) the `Failed` jobs page blows up with an exception, as
`format_error` assumes that a non-nil value will not be a blank string:

```
NoMethodError - undefined method `length' for nil:NilClass:
        que-web/lib/que/web.rb:196:in `truncate'
        que-web/lib/que/web.rb:188:in `format_error'
        que-web/web/views/failing.erb:35:in `block (2 levels) in singleton class'
        que-web/web/views/failing.erb:25:in `each'
        .
        .
```