### PR TITLE
Fix #41 - use hash lookup rather than method call for job_class

### DIFF
--- a/lib/que/web.rb
+++ b/lib/que/web.rb
@@ -140,21 +140,6 @@ module Que
       Pager.new(page, PAGE_SIZE, record_count)
     end
 
-    def search
-      return '%' unless search_param.present?
-      "%#{search_param}%"
-    end
-
-    def search_running(jobs)
-      return jobs unless search_param.present?
-      jobs.select { |job| job.job_class.include? search_param }
-    end
-
-    def search_param
-      return unless params['search'].present?
-      params['search'].gsub(/[^0-9A-Za-z:]/, '')
-    end
-
     after { session[FLASH_KEY] = {} if @sweep_flash }
 
     module Helpers
@@ -167,8 +152,24 @@ module Que
       end
 
       def path_with_search(path)
-        path += "?search=#{search_param}" if search_param.present?
+        path += "?search=#{search_param}" if search_param
         path
+      end
+
+      def search
+        return '%' unless search_param
+        "%#{search_param}%"
+      end
+
+      def search_running(jobs)
+        return jobs unless search_param
+        jobs.select { |job| job.fetch('job_class').include? search_param }
+      end
+
+      def search_param
+        sanitised = (params['search'] || '').gsub(/[^0-9a-z:]i/, '')
+        return if sanitised.empty?
+        sanitised
       end
 
       def active_class(pattern)

--- a/spec/web_spec.rb
+++ b/spec/web_spec.rb
@@ -1,8 +1,18 @@
 require 'spec_helper'
 
 describe Que::Web::Helpers do
+  let(:search) { '' }
+  let(:params) { { 'search' => search } }
+
   subject do
-    Class.new { include Que::Web::Helpers }.new
+    # Capture the params into an ivar so the params method block below captures it
+    params_to_use = params
+
+    Class.new do
+      include Que::Web::Helpers
+
+      define_method(:params) { params_to_use }
+    end.new
   end
 
   def error_job(last_error)
@@ -20,6 +30,46 @@ describe Que::Web::Helpers do
 
     it 'handles empty strings as the last error' do
       subject.format_error(error_job('')).must_equal ''
+    end
+  end
+
+  describe '#search_running' do
+    let(:jobs) do
+      [
+        { 'job_class' => 'JobClassA' },
+        { 'job_class' => 'JobClassB' },
+        { 'job_class' => 'JobClassA2' },
+        { 'job_class' => 'JobClassC' }
+      ]
+    end
+
+    describe 'when the search param is not supplied' do
+      let(:params) { {} }
+
+      it 'returns all the jobs' do
+        subject.search_running(jobs).must_equal(jobs)
+      end
+    end
+
+    describe 'when the search param is blank' do
+      let(:search) { '' }
+
+      it 'returns all the jobs' do
+        subject.search_running(jobs).must_equal(jobs)
+      end
+    end
+
+    describe 'when the search param is present' do
+      let(:search) { 'A' }
+
+      it 'returns only the jobs whose class matches the search' do
+        subject.search_running(jobs).must_equal(
+          [
+            { 'job_class' => 'JobClassA' },
+            { 'job_class' => 'JobClassA2' }
+          ]
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
Calling `Que.worker_states` returns an array of Hashes rather than
objects that directly respond to `#job_class`. Also add a dependency on
activesupport, since it is required for the calls to `#present?`.