### PR TITLE
Fix pagination issue where the same job appears on multiple pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Unreleased
+#### Fixed:
+- Fixed inconsistent pagination when several jobs have the same `run_at`
+
 ### 0.9.3 - 2020-06-17
 #### Added:
 - Set expired_at=NULL when rescheduling job

--- a/lib/que/web/sql.rb
+++ b/lib/que/web/sql.rb
@@ -70,7 +70,7 @@ Que::Web::SQL = {
         job_class ILIKE ($3)
         OR que_jobs.args #>> '{0, job_class}' ILIKE ($3)
       )
-    ORDER BY run_at
+    ORDER BY run_at, id
     LIMIT $1::int
     OFFSET $2::int
   SQL
@@ -88,7 +88,7 @@ Que::Web::SQL = {
         job_class ILIKE ($3)
         OR que_jobs.args #>> '{0, job_class}' ILIKE ($3)
       )
-    ORDER BY run_at
+    ORDER BY run_at, id
     LIMIT $1::int
     OFFSET $2::int
   SQL


### PR DESCRIPTION
This handles scenarios where run_at is the same for multiple jobs, as frequently happens with scheduled jobs. Adding a secondary order by id ensures this order is always deterministic.

As you can see below, prior to this change, job 1870 did not appear in que-web at all, whereas job 1872 appeared on both page 1 & 2:
<img width="318" alt="Screen Shot 2020-10-02 at 7 43 09 AM" src="https://user-images.githubusercontent.com/157270/94937005-e25e7480-0483-11eb-8668-d8d565bcac52.png">
<img width="318" alt="Screen Shot 2020-10-02 at 7 43 24 AM" src="https://user-images.githubusercontent.com/157270/94937016-e4c0ce80-0483-11eb-96e3-234ea02b0792.png">
<img width="326" alt="Screen Shot 2020-10-02 at 7 49 12 AM" src="https://user-images.githubusercontent.com/157270/94937038-e7bbbf00-0483-11eb-853b-1b5db7e063e2.png">
