### PR TITLE
Undefined method `utc' for String

### DIFF
--- a/lib/que/web.rb
+++ b/lib/que/web.rb
@@ -185,6 +185,7 @@ module Que
       end
 
       def relative_time(time)
+        time = Time.utc((t = Date._parse(time))[:year], t[:mon], t[:mday], t[:hour], t[:min], t[:sec]) if time.is_a?(String)
         %{<time class="timeago" datetime="#{time.utc.iso8601}">#{time.utc}</time>}
       end
 

--- a/spec/web_spec.rb
+++ b/spec/web_spec.rb
@@ -72,4 +72,20 @@ describe Que::Web::Helpers do
       end
     end
   end
+
+  describe '#relative_time' do
+    it 'renders a Time object as a <time> HTML element' do
+      time = Time.now
+      _(subject.relative_time(time)).must_equal(
+        %Q(<time class="timeago" datetime="#{time.utc.iso8601}">#{time.utc}</time>)
+      )
+    end
+
+    it 'renders a String object without timezone in the format "YYYY-MM-DD HH:MM:SS" (e.g. "2020-09-06 22:17:03") as a <time> HTML element' do
+      time = '2020-09-06 22:17:03'
+      _(subject.relative_time(time)).must_equal(
+        %Q(<time class="timeago" datetime="2020-09-06T22:17:03Z">2020-09-06 22:17:03 UTC</time>)
+      )
+    end
+  end
 end


### PR DESCRIPTION
# Dependencies
PgSQL 12
ruby: 2.6.5
rails: 5.2.3
pg: 1.1.4
que: 1.0.0.beta4 (commit 065981)
que-web: HEAD (commit 3f7b7b7)

# Reproduce Condition
Visit `/que/scheduled`

# How System Behaves
* System displays the message:
```
NoMethodError at /que/scheduled
undefined method `utc' for "2020-09-06 22:17:03":String
in que-web/lib/que/web.rb in relative_time:188
que-web/web/views/scheduled.erb:26
```

My best guess so far is que-web/lib/que/web.rb:39
```
scheduled_jobs = Que.execute SQL[:scheduled_jobs], [pager.page_size, pager.offset, search]
```
returns `run_at` as a string, example: "2020-09-06 22:17:03"

The `relative_time` helper expects a `Time` object at lib/que/web.rb:189
```
      def relative_time(time)
        %{<time class="timeago" datetime="#{time.utc.iso8601}">#{time.utc}</time>}
      end
```

and the String class is missing `.utc`

Notes:
I base this fix (loosely) on https://github.com/que-rb/que/commit/87d40e7e1501346f4a92871c789df69863eaf94f.