### PR TITLE
Allow que 2

### DIFF
--- a/que-web.gemspec
+++ b/que-web.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "que", "~> 1"
+  spec.add_dependency "que", ">= 1"
   spec.add_dependency "sinatra"
 
   spec.add_development_dependency "bundler", ">= 1.6"


### PR DESCRIPTION
The interface works and loads normally with Que 2.

<img width="694" alt="Screen Shot 2022-03-30 at 12 12 52 AM" src="https://user-images.githubusercontent.com/9451001/160773071-0b01955f-34bc-4145-877b-6c0a902b0467.png">

Tested with:
`que`: 2.0.0.beta1 620786d
`que-web`: 0.9.4

It seems ok to allow `que` `>= 1`.