### PR TITLE
Display kwargs on show job page

### DIFF
--- a/lib/que/web/viewmodels/job.rb
+++ b/lib/que/web/viewmodels/job.rb
@@ -1,8 +1,8 @@
 module Que::Web::Viewmodels
   class Job < Struct.new(
       :priority, :run_at, :id, :job_class, :error_count, :last_error_message,
-      :queue, :last_error_backtrace, :finished_at, :expired_at, :args, :data,
-      :backend_pid)
+      :queue, :last_error_backtrace, :finished_at, :expired_at, :args, :kwargs,
+      :data, :backend_pid)
 
     def initialize(job)
       members.each do |m|

--- a/web/views/show.erb
+++ b/web/views/show.erb
@@ -35,6 +35,10 @@
           <td><pre><%= h JSON.pretty_generate(@job.args) %></pre></td>
         </tr>
         <tr>
+          <th>Kwargs</th>
+          <td><pre><%= h JSON.pretty_generate(@job.kwargs) %></pre></td>
+        </tr>
+        <tr>
           <th>Last Error</th>
           <td>
             <pre><%= h @job.last_error_message %></pre>


### PR DESCRIPTION
### Context
- #105 

Job args are displayed on the show and list pages, but not kwargs. 

When debugging failed jobs with kwargs, it is critical to have this information. 

### Change
- Add kwargs to the show job page. 

### Discussion
- I considered also adding kwargs to the list pages but it pushed the table too wide. 
- There doesn't appear to be test coverage for this part of the code, so I didn't add any. I did test it manually though. 